### PR TITLE
fix escaping double quotes in toJSON method

### DIFF
--- a/java/src/main/java/com/outlyer/jmx/jmxquery/JMXMetric.java
+++ b/java/src/main/java/com/outlyer/jmx/jmxquery/JMXMetric.java
@@ -332,7 +332,7 @@ public class JMXMetric {
                     (this.value instanceof Boolean)) {
                 json += ", \"value\" : " + this.value.toString();
             } else {
-                json += ", \"value\" : \"" + this.value.toString() + "\"";
+                json += ", \"value\" : \"" + this.value.toString().replace("\"", "\\\"") + "\"";
             }
         }
         json += "}";


### PR DESCRIPTION
I have error in tomcat jmx output from my tomcat server. It is not valid json, because that have not esacaped double quotes. 

example output:
`{"mBeanName" : "Catalina:type=RequestProcessor,worker=\"http-bio-8080\",name=HttpRequest37", "attribute" : "rpName", "attributeType" : "ObjectName", "value" : "Catalina:type=RequestProcessor,worker="http-bio-8080",name=HttpRequest37"}`

